### PR TITLE
ch_06-008. 괄호 짝 맞추기

### DIFF
--- a/src/youngrongoh/ch_06/solution_008.py
+++ b/src/youngrongoh/ch_06/solution_008.py
@@ -1,0 +1,8 @@
+def solution(s):
+  stack = []
+  for paren in s:
+    if paren == ')' and stack[-1] == '(':
+      stack.pop()
+      continue
+    stack.append(paren)
+  return len(stack) == 0

--- a/src/youngrongoh/ch_06/solution_008.py
+++ b/src/youngrongoh/ch_06/solution_008.py
@@ -1,8 +1,19 @@
 def solution(s):
   stack = []
   for paren in s:
-    if paren == ')' and stack[-1] == '(':
-      stack.pop()
-      continue
+    if paren == ')':
+      if len(stack) == 0: # 닫힌 괄호가 나왔을 때 스택이 비어있으면 무조건 False
+        return False
+      if stack.pop() == '(':
+        continue
+      else: # 닫힌 괄호가 나왔을 때 스택 top 값이 열린 괄호가 아니면 무조건 False
+        return False
+
     stack.append(paren)
   return len(stack) == 0
+
+"""
+# 추가 테스트 케이스 1
+- 입력: ')()'
+- 이유: 열린 괄호가 스택에 하나도 없을 때 닫힌 괄호가 나온 경우 pop을 호출하거나 stack[-1]로 top을 조회하면 IndexError 발생
+"""


### PR DESCRIPTION
## 소요시간
5분

## 사용한 자료구조, 알고리즘
리스트를 스택을 대체해서 사용

## 해당 자료구조, 알고리즘을 사용한 근거
닫힌 괄호가 나왔을 때 스택에 <ins>마지막으로 담긴 값</ins>이 열린 괄호인지 확인하고 제거해야 하므로 스택을 사용했습니다.

## 어려웠던 구현 포인트
.

## 구현한 코드의 시간 복잡도
$O(N)$

- 입력 문자열 전체($N$)를 1회 순회하기 때문

## 추가한 테스트 케이스와 그 이유
.

## 개선이 필요한 부분은?
.