### PR TITLE
ch_06-010. 괄호 회전하기

### DIFF
--- a/src/youngrongoh/ch_06/solution_010.py
+++ b/src/youngrongoh/ch_06/solution_010.py
@@ -1,0 +1,36 @@
+def solution(s):
+  answer = 0
+  
+  for x in range(len(s)):
+    # 문자열 회전
+    turned = s[x:] + s[:x]
+    if check_right(turned):
+      answer += 1
+  
+  return answer
+
+openings = ('(', '{', '[')
+couples = {
+    ')': '(',
+    '}': '{',
+    ']': '[',
+}
+
+def check_right(s):
+  stack = []
+  for paren in s:
+    if paren in openings:
+      stack.append(paren)
+      continue
+
+    # 닫는 괄호인 경우
+    if stack: # 스택이 비어있는데 top 조회하면 IndexError 발생하므로 체크
+      top = stack[-1]
+      # 스택 top과 닫는 괄호가 짝이 맞으면 스택에서 상쇄
+      if top == couples[paren]:
+        stack.pop()
+    # 닫는 괄호가 나왔는데 스택이 비어있으면 항상 False
+    else:
+      return False
+
+  return len(stack) == 0


### PR DESCRIPTION
## 소요시간
20분

## 사용한 자료구조, 알고리즘
스택, 딕셔너리, 리스트

## 해당 자료구조, 알고리즘을 사용한 근거
- 스택
  - 닫는 괄호가 나왔을 때 <ins>마지막에 넣은 값</ins>을 조회하고, 짝이 맞는 경우 상쇄 시키기 위해 사용했습니다.
- 딕셔너리
  - 닫는 괄호의 짝을 찾기 위해 사용했습니다.
- 리스트
  - 열린 괄호가 맞는지 체크하기 위해 열린 괄호 리스트를 선언해두고 사용했습니다.

## 어려웠던 구현 포인트
- 닫는 괄호가 top과 짝이 맞는지 체크해주어야 한다는 것을 구현 로직을 한 번 실행해보고 알았습니다.
  - 하지만 딕셔너리를 이용해 맵핑해는 방식으로 금방 해결하였습니다.

## 구현한 코드의 시간 복잡도
$O(N^2)$
- 입력 문자열의 길이($N$)만큼의 순회를 중첩으로 수행하고 있습니다.

## 추가한 테스트 케이스와 그 이유
없습니다.
-008번과 다르게, 이번에는 닫는 괄호만 있는 테스트 케이스도 있었고, 대부분의 테스트 케이스에서 회전하면서 닫는 괄호로 시작하는 케이스가 생기게 되기 때문에 테스트 케이스를 따로 추가하지 않았습니다.

## 개선이 필요한 부분은?
